### PR TITLE
Fix wc-list-orders fatal TypeError on refunds in range (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.2] - 2026-07-26
+
+### Fixed
+- `wc-list-orders` threw a fatal `TypeError` (HTTP 500, surfaced over MCP as a generic error) whenever a refund fell in the queried date range, making the ability unusable on any store that issues refunds. `list_orders()` built the `wc_get_orders()` query without a `type`, so under HPOS the result also contained `WC_Order_Refund` objects, which `format_order()` (typed `\WC_Order`) rejected on the first one. The query is now restricted to `'type' => 'shop_order'`, which excludes refunds and keeps `total` / `max_num_pages` honest (a per-row `instanceof` guard would not). Reproduced end-to-end on WooCommerce 10.8.1 with HPOS. (#21)
+
 ## [1.3.1] - 2026-07-24
 
 ### Fixed

--- a/lw-site-manager.php
+++ b/lw-site-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: LW Site Manager
  * Plugin URI: https://github.com/lwplugins/lw-site-manager
  * Description: Lightweight site manager — full site maintenance via AI/REST using Abilities API.
- * Version: 1.3.1
+ * Version: 1.3.2
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Author: LW Plugins
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'LW_SITE_MANAGER_VERSION', '1.3.1' );
+define( 'LW_SITE_MANAGER_VERSION', '1.3.2' );
 define( 'LW_SITE_MANAGER_FILE', __FILE__ );
 define( 'LW_SITE_MANAGER_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LW_SITE_MANAGER_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: site-manager, maintenance, ai, rest-api, abilities
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,9 @@ Yes, LW Site Manager provides similar functionality to MainWP but uses the nativ
 3. Backup creation options
 
 == Changelog ==
+
+= 1.3.2 =
+* Fix: wc-list-orders crashed with a fatal TypeError (HTTP 500 / generic MCP error) whenever a refund fell in the queried range. With HPOS, wc_get_orders() also returns refund objects, which format_order() could not accept. The query is now restricted to the shop_order type, so refunds are excluded and the total / page counts stay correct (#21)
 
 = 1.3.1 =
 * Fix: upload-media failed with "cURL error 60: SSL certificate problem" whenever the source URL was served with a self-signed or otherwise untrusted certificate — including when the site was downloading a file from itself. Certificate verification is now skipped for URLs on this site, where there is no man-in-the-middle position to defend against (#18)

--- a/src/Services/WooCommerce/OrderManager.php
+++ b/src/Services/WooCommerce/OrderManager.php
@@ -20,6 +20,11 @@ class OrderManager extends AbstractService {
         }
 
         $args = [
+            // Restrict to orders only. Without this, HPOS also returns
+            // WC_Order_Refund objects, which format_order() (typed \WC_Order)
+            // cannot accept — see issue #21. It also keeps total / max_num_pages
+            // honest, which a per-row instanceof guard would not.
+            'type'     => 'shop_order',
             'limit'    => min( (int) ( $input['limit'] ?? 20 ), 100 ),
             'offset'   => (int) ( $input['offset'] ?? 0 ),
             'orderby'  => $input['orderby'] ?? 'date',

--- a/tests/Unit/Services/WooCommerce/OrderManagerTest.php
+++ b/tests/Unit/Services/WooCommerce/OrderManagerTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit tests for the WooCommerce OrderManager service.
+ *
+ * Regression guard for issue #21: list_orders() must restrict wc_get_orders()
+ * to the `shop_order` type. Under HPOS, an unrestricted query also returns
+ * WC_Order_Refund objects, and format_order() (typed \WC_Order) then fatals.
+ *
+ * @package LightweightPlugins\SiteManager\Tests\Unit\Services\WooCommerce
+ */
+
+declare(strict_types=1);
+
+namespace LightweightPlugins\SiteManager\Tests\Unit\Services\WooCommerce;
+
+use PHPUnit\Framework\TestCase;
+use LightweightPlugins\SiteManager\Services\WooCommerce\OrderManager;
+
+/**
+ * Tests for OrderManager::list_orders().
+ *
+ * Relies on the `WooCommerce` class stub and the arg-capturing `wc_get_orders`
+ * stub defined in tests/stubs/wordpress-functions.php.
+ */
+final class OrderManagerTest extends TestCase {
+
+    protected function tearDown(): void {
+        unset( $GLOBALS['wc_get_orders_last_args'] );
+        parent::tearDown();
+    }
+
+    /**
+     * Issue #21: the query must be restricted to orders so HPOS never hands a
+     * refund (WC_Order_Refund) object to format_order().
+     */
+    public function test_list_orders_restricts_query_to_shop_order_type(): void {
+        OrderManager::list_orders( [ 'limit' => 1 ] );
+
+        $this->assertArrayHasKey( 'wc_get_orders_last_args', $GLOBALS );
+        $this->assertArrayHasKey( 'type', $GLOBALS['wc_get_orders_last_args'] );
+        $this->assertSame( 'shop_order', $GLOBALS['wc_get_orders_last_args']['type'] );
+    }
+}

--- a/tests/stubs/wordpress-functions.php
+++ b/tests/stubs/wordpress-functions.php
@@ -1700,3 +1700,34 @@ function reset_wp_post_meta(): void {
     global $wp_post_meta;
     $wp_post_meta = [];
 }
+
+// ============================================================================
+// WooCommerce test doubles
+// ============================================================================
+
+if ( ! class_exists( 'WooCommerce' ) ) {
+    /**
+     * Minimal WooCommerce stand-in so the `class_exists( 'WooCommerce' )` guards
+     * in the services pass under unit tests (no real WooCommerce is loaded).
+     */
+    class WooCommerce {}
+}
+
+if ( ! function_exists( 'wc_get_orders' ) ) {
+    /**
+     * Test double for wc_get_orders(): records the query args it was called with
+     * in $GLOBALS['wc_get_orders_last_args'] and returns a paginated-shape result
+     * ($GLOBALS['wc_get_orders_result'] when set, otherwise an empty result).
+     *
+     * @param array<string, mixed> $args Query args from the code under test.
+     * @return object
+     */
+    function wc_get_orders( array $args = [] ): object {
+        $GLOBALS['wc_get_orders_last_args'] = $args;
+        return $GLOBALS['wc_get_orders_result'] ?? (object) [
+            'orders'        => [],
+            'total'         => 0,
+            'max_num_pages' => 0,
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #21.

## Problem

`wc-list-orders` threw a fatal `TypeError` (HTTP 500, surfaced over MCP as a generic error) whenever a refund fell in the queried date range, making the ability unusable on any store that issues refunds:

```
TypeError: OrderManager::format_order(): Argument #1 ($order) must be of type
WC_Order, Automattic\WooCommerce\Admin\Overrides\OrderRefund given,
called in .../OrderManager.php on line 58
```

`list_orders()` built the `wc_get_orders()` query without a `type`, so under **HPOS** the result also contained `WC_Order_Refund` objects. `format_order()` is typed `\WC_Order` and rejected the first refund.

## Fix

Restrict the query to `'type' => 'shop_order'`. This excludes refunds and keeps `total` / `max_num_pages` honest — a per-row `instanceof` guard would stop the fatal but leave the counts (and pagination) wrong.

This is the only `wc_get_orders()` call site; the report/aggregator code already scopes to `shop_order` via explicit SQL.

## Tests

- Added `tests/Unit/Services/WooCommerce/OrderManagerTest.php` — RED before the fix, GREEN after — asserting the query is restricted to `shop_order` (plus a reusable `WooCommerce` class stub and an arg-capturing `wc_get_orders` stub in the shared stub file).
- Full suite green (381 tests), `composer phpcs` clean, PHPStan L5 no errors.

## Verified end-to-end on real WordPress

On the WC 10.8.1 + HPOS test site: created a scratch order + refund, reproduced the exact `TypeError` on the deployed 1.3.1, deployed the fix, confirmed `list_orders` returns orders with the refund correctly excluded and no fatal, then removed the scratch data.

Bumps to **1.3.2** (plugin header + constant, `readme.txt` stable tag + changelog, `CHANGELOG.md`).