### PR TITLE
Don't force wordpress/mcp-adapter on Composer consumers (bundle in ZIP only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,15 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: composer install --no-dev --optimize-autoloader --no-interaction
 
+      # The MCP adapter is a dev-only Composer dependency so that a
+      # `composer require lwplugins/lw-site-manager` does NOT drag it into
+      # consumer projects (on Bedrock it is type:wordpress-plugin and would
+      # install as a stray plugin). The wordpress.org ZIP still bundles it here
+      # so the built-in MCP server keeps working out of the box.
+      - name: Bundle the MCP adapter into the release ZIP
+        if: steps.check_release.outputs.exists == 'false'
+        run: composer require wordpress/mcp-adapter:^0.5 --no-dev --optimize-autoloader --no-interaction
+
       - name: Create release ZIP
         if: steps.check_release.outputs.exists == 'false'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.3] - 2026-08-07
+
+### Changed
+- `wordpress/mcp-adapter` moved from `require` to `require-dev` + `suggest`, so `composer require lwplugins/lw-site-manager` no longer pulls it into consumer projects. Since mcp-adapter v0.5 the package is `type: wordpress-plugin`, so on Composer/Bedrock sites `composer/installers` was dropping it into `web/app/plugins/` as an unexpected standalone "MCP Adapter" plugin. The WordPress.org release ZIP still bundles the adapter — it is injected during the release workflow (`composer require … --no-dev` after the production install) — so the built-in MCP server keeps working out of the box for ZIP installs. Composer/Bedrock users who want the MCP server install the adapter (or the canonical MCP Adapter plugin) themselves. `Mcp\Bootstrap` already no-ops when the adapter class is absent, so the REST / Abilities API surface is unaffected.
+
 ## [1.3.2] - 2026-07-26
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
 	"minimum-stability": "stable",
 	"prefer-stable": true,
 	"require": {
-		"php": ">=8.2",
-		"wordpress/mcp-adapter": "^0.5"
+		"php": ">=8.2"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.2",
@@ -25,8 +24,12 @@
 		"phpunit/phpunit": "^9.6",
 		"squizlabs/php_codesniffer": "^3.13",
 		"szepeviktor/phpstan-wordpress": "^2.0",
+		"wordpress/mcp-adapter": "^0.5",
 		"wp-coding-standards/wpcs": "^3.3",
 		"yoast/phpunit-polyfills": "^4.0"
+	},
+	"suggest": {
+		"wordpress/mcp-adapter": "^0.5 — powers the built-in MCP server (LW Plugins → AI / MCP). Not needed for the REST / Abilities API. Bundled in the wordpress.org ZIP; Composer installs that want the MCP server must add it (or the canonical MCP Adapter plugin) themselves."
 	},
 	"autoload": {
 		"psr-4": {

--- a/lw-site-manager.php
+++ b/lw-site-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: LW Site Manager
  * Plugin URI: https://github.com/lwplugins/lw-site-manager
  * Description: Lightweight site manager — full site maintenance via AI/REST using Abilities API.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Author: LW Plugins
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'LW_SITE_MANAGER_VERSION', '1.3.2' );
+define( 'LW_SITE_MANAGER_VERSION', '1.3.3' );
 define( 'LW_SITE_MANAGER_FILE', __FILE__ );
 define( 'LW_SITE_MANAGER_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LW_SITE_MANAGER_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: site-manager, maintenance, ai, rest-api, abilities
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,9 @@ Yes, LW Site Manager provides similar functionality to MainWP but uses the nativ
 3. Backup creation options
 
 == Changelog ==
+
+= 1.3.3 =
+* Change: The MCP Adapter (wordpress/mcp-adapter) is no longer a hard Composer dependency. It stays bundled in the WordPress.org ZIP, so the built-in MCP server keeps working out of the box; but `composer require lwplugins/lw-site-manager` no longer pulls it in. Since mcp-adapter v0.5 is type:wordpress-plugin, Composer/Bedrock sites were getting a stray "MCP Adapter" plugin installed under web/app/plugins. Composer installs that want the MCP server should add wordpress/mcp-adapter (or the canonical MCP Adapter plugin) themselves — the server no-ops gracefully when it is absent, and the REST / Abilities API is unaffected.
 
 = 1.3.2 =
 * Fix: wc-list-orders crashed with a fatal TypeError (HTTP 500 / generic MCP error) whenever a refund fell in the queried range. With HPOS, wc_get_orders() also returns refund objects, which format_order() could not accept. The query is now restricted to the shop_order type, so refunds are excluded and the total / page counts stay correct (#21)


### PR DESCRIPTION
## Problem

`wordpress/mcp-adapter` was a hard `require` in `composer.json`, so `composer require lwplugins/lw-site-manager` pulled it into every consumer project. Since **mcp-adapter v0.5** the package declares `"type": "wordpress-plugin"` (and ships a `Plugin Name: MCP Adapter` bootstrap). On Composer/Bedrock sites `composer/installers` therefore installed it into `web/app/plugins/mcp-adapter` — a stray, activatable **"MCP Adapter" plugin** that the site owner never asked for.

Observed live on a Bedrock client site (an unexpected `web/app/plugins/mcp-adapter` alongside the vendor copy). It's also purely dead weight for anyone using only the REST / Abilities API.

## Change

- **`composer.json`**: move `wordpress/mcp-adapter` from `require` → `require-dev` (kept so local PHPStan/PHPUnit still analyse `src/Mcp/` against the real adapter) and add a `suggest` entry documenting it for consumers.
- **`.github/workflows/release.yml`**: after the production install, inject the adapter into the ZIP build with an explicit `composer require wordpress/mcp-adapter:^0.5 --no-dev …`, so the WordPress.org ZIP still bundles it.

### Result

| Install method | mcp-adapter bundled? |
|---|---|
| WordPress.org ZIP | ✅ yes (injected during the release build) — MCP works out of the box |
| Composer / Bedrock | ❌ no — no stray plugin; add `wordpress/mcp-adapter` yourself for the MCP server |

`Mcp\Bootstrap` already `class_exists()`-guards and no-ops when the adapter is absent, so the REST / Abilities API surface is unaffected for Composer installs without it. `composer audit --no-dev` now reports **no production dependencies** shipped from us.

## Not solved here (interim)

The ZIP-bundled copy is still unscoped `\WP\MCP\`, so a wp.org-ZIP user who also runs WooCommerce (which bundles its own mcp-adapter) remains in the first-wins version-skew situation — unchanged by this PR. The clean end state is to drop the ZIP bundle too once the canonical adapter ships as a wp.org plugin or lands in core, and switch to `Requires Plugins:` / core.

## Verification

- `composer analyse` (PHPStan L5): **no errors** (adapter still present via require-dev)
- `composer phpcs`: clean
- `vendor/bin/phpunit`: **381/381**
- `composer validate`: valid

Bumps to **1.3.3**.