### PR TITLE
Fix release ZIP build (composer require --update-no-dev) + manual trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -57,7 +58,7 @@ jobs:
       # so the built-in MCP server keeps working out of the box.
       - name: Bundle the MCP adapter into the release ZIP
         if: steps.check_release.outputs.exists == 'false'
-        run: composer require wordpress/mcp-adapter:^0.5 --no-dev --optimize-autoloader --no-interaction
+        run: composer require wordpress/mcp-adapter:^0.5 --update-no-dev --optimize-autoloader --no-interaction
 
       - name: Create release ZIP
         if: steps.check_release.outputs.exists == 'false'


### PR DESCRIPTION
The MCP-adapter bundling step added in #23 used `composer require … --no-dev`, but `composer require` has no `--no-dev` option — that belongs to `composer install`. The correct flag is `--update-no-dev`. The **v1.3.3 release build failed** at that step, before the tag/release was created (so no v1.3.3 tag or release exists).

- Fix the flag: `--no-dev` → `--update-no-dev`.
- Add a `workflow_dispatch` trigger so a release can be re-run manually (used here to release v1.3.3 without a redundant version bump).

CI-only change; no plugin code or version change.