### PR TITLE
Make WooCommerce product reviews first-class in the comment abilities (1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.5.0] - 2026-08-10
+
+### Added
+- WooCommerce product reviews now report `rating` (1-5, `null` when unset) and `verified` (verified purchaser). Both live in comment meta, so previously a review came back as plain text and an agent asked to moderate reviews could not see what it was moderating. The fields appear only on `type: "review"` rows.
+
+### Changed
+- **`list-comments` now defaults to `type: 'comment'`.** Whether product reviews appeared in the default listing was previously left to chance. WooCommerce hides reviews from comment queries via `comments_clauses`, but that filter bails out whenever any of a dozen query vars is set — `type__not_in` among them, which LearnDash populates with `ld_review`. The identical call therefore returned reviews on one site and not on another. WordPress maps `type => 'comment'` to `comment_type IN ( '', 'comment' )`, so legacy comments stored with an empty type are still returned. Pass `type=review` for reviews, or `type=all` to opt back into everything.
+- **`comment-counts` counts comments and product reviews separately** instead of summing them, and no longer relies on `wp_count_comments()` — WooCommerce filters that through `get_comments()`, inheriting the same environment-dependence. Reviews now appear under a `reviews` key with the same status breakdown. Counting is in the new `Services\Comments\CommentCounter`.
+
+### Fixed
+- The comment abilities' declared output schema did not match what they return: it advertised `author_name` and `avatar_url` where the fields are `author` and `avatar`, and omitted `agent`, `replies_count`, `rating` and `verified` entirely. The `comment-counts` schema listed `pending` and `total_moderated`, which the ability never returned, while omitting `awaiting` and `post_trashed`, which it did. Schemas are how an agent learns which fields exist, so the drift actively misled callers.
+
+### Notes
+- WooCommerce **order notes** are unaffected: they are `comment_type = 'order_note'`, which WooCommerce excludes from every comment query unconditionally, and the plugin already handles them through the dedicated `wc-list-order-notes` / `wc-add-order-note` abilities.
+- Verified end-to-end on a live WooCommerce 11.0 store: with a review present, the default `list-comments` no longer returns it, `type=review` returns it with `rating: 4` and `verified: true`, a plain comment carries no rating fields, and `comment-counts` reports the two groups separately.
+
 ## [1.4.0] - 2026-08-07
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.5.0] - 2026-08-10
+## [1.4.1] - 2026-08-10
 
 ### Added
 - WooCommerce product reviews now report `rating` (1-5, `null` when unset) and `verified` (verified purchaser). Both live in comment meta, so previously a review came back as plain text and an agent asked to moderate reviews could not see what it was moderating. The fields appear only on `type: "review"` rows.

--- a/lw-site-manager.php
+++ b/lw-site-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: LW Site Manager
  * Plugin URI: https://github.com/lwplugins/lw-site-manager
  * Description: Lightweight site manager — full site maintenance via AI/REST using Abilities API.
- * Version: 1.5.0
+ * Version: 1.4.1
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Author: LW Plugins
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'LW_SITE_MANAGER_VERSION', '1.5.0' );
+define( 'LW_SITE_MANAGER_VERSION', '1.4.1' );
 define( 'LW_SITE_MANAGER_FILE', __FILE__ );
 define( 'LW_SITE_MANAGER_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LW_SITE_MANAGER_URL', plugin_dir_url( __FILE__ ) );

--- a/lw-site-manager.php
+++ b/lw-site-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name: LW Site Manager
  * Plugin URI: https://github.com/lwplugins/lw-site-manager
  * Description: Lightweight site manager — full site maintenance via AI/REST using Abilities API.
- * Version: 1.4.0
+ * Version: 1.5.0
  * Requires at least: 6.9
  * Requires PHP: 8.2
  * Author: LW Plugins
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants.
-define( 'LW_SITE_MANAGER_VERSION', '1.4.0' );
+define( 'LW_SITE_MANAGER_VERSION', '1.5.0' );
 define( 'LW_SITE_MANAGER_FILE', __FILE__ );
 define( 'LW_SITE_MANAGER_DIR', plugin_dir_path( __FILE__ ) );
 define( 'LW_SITE_MANAGER_URL', plugin_dir_url( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: site-manager, maintenance, ai, rest-api, abilities
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,12 @@ Yes, LW Site Manager provides similar functionality to MainWP but uses the nativ
 3. Backup creation options
 
 == Changelog ==
+
+= 1.5.0 =
+* New: WooCommerce product reviews now report their star rating and verified-purchase flag. Previously a review came back as plain text, so an agent asked to moderate reviews could not see what it was moderating.
+* Change: list-comments now defaults to regular comments only. Whether product reviews appeared was previously up to chance — WooCommerce hides them, but stops doing so when another plugin (LearnDash, for one) touches the comment query, so the same call returned different results on different sites. Pass type=review for reviews, or type=all for everything.
+* Change: comment-counts counts comments and product reviews separately instead of summing them. Reviews now appear under a "reviews" key with the same breakdown.
+* Fix: The documented output of the comment abilities matches what they actually return. The schema advertised author_name and avatar_url, but the fields are author and avatar, and agent, replies_count, rating and verified were missing entirely. The comment-counts schema listed fields the ability never returned.
 
 = 1.4.0 =
 * Security: Abilities now check permissions against the specific object they act on, not just a general capability. Previously a low-privileged user with an application password could act far beyond their role: a Contributor could permanently delete any post site-wide, read every author's drafts and private posts, and (on WooCommerce stores) list all customer names, emails and phone numbers, read protected order meta and delete orders; an Author could permanently delete any media file; and a user manager or WooCommerce shop manager could reset the administrator's password or promote themselves to administrator. All confirmed fixed and covered by tests.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: site-manager, maintenance, ai, rest-api, abilities
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.5.0
+Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,7 +156,7 @@ Yes, LW Site Manager provides similar functionality to MainWP but uses the nativ
 
 == Changelog ==
 
-= 1.5.0 =
+= 1.4.1 =
 * New: WooCommerce product reviews now report their star rating and verified-purchase flag. Previously a review came back as plain text, so an agent asked to moderate reviews could not see what it was moderating.
 * Change: list-comments now defaults to regular comments only. Whether product reviews appeared was previously up to chance — WooCommerce hides them, but stops doing so when another plugin (LearnDash, for one) touches the comment query, so the same call returned different results on different sites. Pass type=review for reviews, or type=all for everything.
 * Change: comment-counts counts comments and product reviews separately instead of summing them. Reviews now appear under a "reviews" key with the same breakdown.

--- a/src/Abilities/Definitions/CommentAbilities.php
+++ b/src/Abilities/Definitions/CommentAbilities.php
@@ -62,7 +62,8 @@ class CommentAbilities {
                         ],
                         'type' => [
                             'type'        => 'string',
-                            'description' => 'Filter by type (comment, pingback, trackback)',
+                            'default'     => 'comment',
+                            'description' => "Filter by type. Defaults to 'comment' (regular comments, including legacy ones stored with an empty type). Use 'review' for WooCommerce product reviews, 'pingback' / 'trackback' for those, or 'all' for every type.",
                         ],
                         'search' => [
                             'type'        => 'string',
@@ -133,14 +134,30 @@ class CommentAbilities {
                     ],
                 ],
                 'output_schema' => [
-                    'type'       => 'object',
-                    'properties' => [
-                        'total'           => [ 'type' => 'integer' ],
-                        'approved'        => [ 'type' => 'integer' ],
-                        'pending'         => [ 'type' => 'integer' ],
-                        'spam'            => [ 'type' => 'integer' ],
-                        'trash'           => [ 'type' => 'integer' ],
-                        'total_moderated' => [ 'type' => 'integer' ],
+                    'type'        => 'object',
+                    'description' => 'Counts for regular comments. WooCommerce product reviews are counted separately under "reviews" and are not included in these numbers.',
+                    'properties'  => [
+                        'total'        => [
+                            'type'        => 'integer',
+                            'description' => 'Approved plus awaiting moderation (excludes spam and trash)',
+                        ],
+                        'approved'     => [ 'type' => 'integer' ],
+                        'awaiting'     => [ 'type' => 'integer' ],
+                        'spam'         => [ 'type' => 'integer' ],
+                        'trash'        => [ 'type' => 'integer' ],
+                        'post_trashed' => [ 'type' => 'integer' ],
+                        'reviews'      => [
+                            'type'        => 'object',
+                            'description' => 'The same counts for WooCommerce product reviews',
+                            'properties'  => [
+                                'total'        => [ 'type' => 'integer' ],
+                                'approved'     => [ 'type' => 'integer' ],
+                                'awaiting'     => [ 'type' => 'integer' ],
+                                'spam'         => [ 'type' => 'integer' ],
+                                'trash'        => [ 'type' => 'integer' ],
+                                'post_trashed' => [ 'type' => 'integer' ],
+                            ],
+                        ],
                     ],
                 ],
                 'execute_callback'    => [ CommentManager::class, 'get_counts' ],
@@ -434,21 +451,37 @@ class CommentAbilities {
         return [
             'type'       => 'object',
             'properties' => [
-                'id'           => [ 'type' => 'integer' ],
-                'post_id'      => [ 'type' => 'integer' ],
-                'post_title'   => [ 'type' => 'string' ],
-                'author_name'  => [ 'type' => 'string' ],
-                'author_email' => [ 'type' => 'string' ],
-                'author_url'   => [ 'type' => 'string' ],
-                'author_ip'    => [ 'type' => 'string' ],
-                'content'      => [ 'type' => 'string' ],
-                'date'         => [ 'type' => 'string' ],
-                'date_gmt'     => [ 'type' => 'string' ],
-                'status'       => [ 'type' => 'string' ],
-                'type'         => [ 'type' => 'string' ],
-                'parent'       => [ 'type' => 'integer' ],
-                'user_id'      => [ 'type' => 'integer' ],
-                'avatar_url'   => [ 'type' => 'string' ],
+                'id'            => [ 'type' => 'integer' ],
+                'post_id'       => [ 'type' => 'integer' ],
+                'author'        => [ 'type' => 'string' ],
+                'author_email'  => [ 'type' => 'string' ],
+                'content'       => [ 'type' => 'string' ],
+                'date'          => [ 'type' => 'string' ],
+                'status'        => [ 'type' => 'string' ],
+                'type'          => [
+                    'type'        => 'string',
+                    'description' => "Comment type: 'comment', 'review' (WooCommerce product review), 'pingback', 'trackback'",
+                ],
+                'parent'        => [ 'type' => 'integer' ],
+                // Detailed responses only (get-comment and the moderation
+                // abilities); absent from list-comments rows.
+                'post_title'    => [ 'type' => 'string' ],
+                'author_url'    => [ 'type' => 'string' ],
+                'author_ip'     => [ 'type' => 'string' ],
+                'date_gmt'      => [ 'type' => 'string' ],
+                'user_id'       => [ 'type' => 'integer' ],
+                'agent'         => [ 'type' => 'string' ],
+                'avatar'        => [ 'type' => 'string' ],
+                'replies_count' => [ 'type' => 'integer' ],
+                // WooCommerce product reviews only.
+                'rating'        => [
+                    'type'        => [ 'integer', 'null' ],
+                    'description' => 'Star rating 1-5, null when the review has none. Present only when type is "review".',
+                ],
+                'verified'      => [
+                    'type'        => 'boolean',
+                    'description' => 'Whether the reviewer is a verified purchaser. Present only when type is "review".',
+                ],
             ],
         ];
     }

--- a/src/Services/CommentManager.php
+++ b/src/Services/CommentManager.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace LightweightPlugins\SiteManager\Services;
 
+use LightweightPlugins\SiteManager\Services\Comments\CommentCounter;
+
 class CommentManager extends AbstractService {
 
     /**
@@ -16,6 +18,16 @@ class CommentManager extends AbstractService {
         $args = [
             'orderby' => $input['orderby'] ?? 'comment_date',
             'order'   => $input['order'] ?? 'DESC',
+            // Pin the type. Left unset, whether WooCommerce product reviews
+            // appear here depends on which other plugins are active: WooCommerce
+            // excludes reviews from comment queries, but bails out of that
+            // filter when any of a dozen query vars is set (type__not_in among
+            // them, which LearnDash populates), so the same call returned
+            // different rows per site. WordPress maps 'comment' to
+            // comment_type IN ( '', 'comment' ), so legacy comments stored with
+            // an empty type are still included. Pass type=review for reviews,
+            // or type=all to opt back into everything.
+            'type'    => $input['type'] ?? 'comment',
         ];
 
         // Apply pagination
@@ -29,11 +41,6 @@ class CommentManager extends AbstractService {
         // Filter by post
         if ( ! empty( $input['post_id'] ) ) {
             $args['post_id'] = $input['post_id'];
-        }
-
-        // Filter by type
-        if ( ! empty( $input['type'] ) ) {
-            $args['type'] = $input['type'];
         }
 
         // Search
@@ -334,16 +341,13 @@ class CommentManager extends AbstractService {
      * Get comment counts by status
      */
     public static function get_counts( array $input = [] ): array {
-        $counts = wp_count_comments( $input['post_id'] ?? 0 );
+        $post_id = (int) ( $input['post_id'] ?? 0 );
 
-        return [
-            'total'            => (int) $counts->total_comments,
-            'approved'         => (int) $counts->approved,
-            'awaiting'         => (int) $counts->moderated,
-            'spam'             => (int) $counts->spam,
-            'trash'            => (int) $counts->trash,
-            'post_trashed'     => (int) $counts->{'post-trashed'},
-        ];
+        // Comments and product reviews are counted separately: they are
+        // different things, and summing them made the totals depend on which
+        // other plugins the site runs. See CommentCounter.
+        return CommentCounter::forType( 'comment', $post_id )
+            + [ 'reviews' => CommentCounter::forType( 'review', $post_id ) ];
     }
 
     /**
@@ -361,6 +365,16 @@ class CommentManager extends AbstractService {
             'parent'       => (int) $comment->comment_parent,
             'type'         => $comment->comment_type ?: 'comment',
         ];
+
+        // WooCommerce stores the star rating and the verified-purchase flag as
+        // comment meta. Without them a review is just text, and an agent asked
+        // to moderate reviews cannot see what it is moderating.
+        if ( 'review' === $comment->comment_type ) {
+            $rating = get_comment_meta( (int) $comment->comment_ID, 'rating', true );
+
+            $data['rating']   = ( '' === $rating || null === $rating ) ? null : (int) $rating;
+            $data['verified'] = (bool) get_comment_meta( (int) $comment->comment_ID, 'verified', true );
+        }
 
         if ( $detailed ) {
             $data['author_url'] = $comment->comment_author_url;

--- a/src/Services/Comments/CommentCounter.php
+++ b/src/Services/Comments/CommentCounter.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Deterministic comment counts, split by comment type.
+ */
+
+declare(strict_types=1);
+
+namespace LightweightPlugins\SiteManager\Services\Comments;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Counts comments per status for one comment type at a time.
+ *
+ * WordPress's own wp_count_comments() cannot separate types, and on a
+ * WooCommerce store its result silently varies: WooCommerce filters it through
+ * get_comments(), whose review-excluding clause bails out whenever another
+ * plugin sets one of a dozen query vars. The same call therefore returned
+ * different totals per site, with product reviews sometimes folded into the
+ * comment counts and sometimes not.
+ *
+ * Querying each type explicitly removes that ambiguity — the numbers now mean
+ * the same thing everywhere, and match what list-comments returns for the same
+ * type.
+ */
+final class CommentCounter {
+
+    /**
+     * Response key => WP_Comment_Query status.
+     */
+    private const STATUSES = [
+        'approved'     => 'approve',
+        'awaiting'     => 'hold',
+        'spam'         => 'spam',
+        'trash'        => 'trash',
+        'post_trashed' => 'post-trashed',
+    ];
+
+    /**
+     * Count one comment type per status.
+     *
+     * `total` mirrors wp_count_comments()'s total_comments: approved plus
+     * awaiting moderation, excluding spam and trash.
+     *
+     * @param string $type   Comment type ('comment', 'review', ...).
+     * @param int    $postId Restrict to one post, or 0 for the whole site.
+     * @return array<string, int>
+     */
+    public static function forType( string $type, int $postId = 0 ): array {
+        $counts = [];
+
+        foreach ( self::STATUSES as $key => $status ) {
+            $args = [
+                'type'                      => $type,
+                'status'                    => $status,
+                'count'                     => true,
+                'orderby'                   => 'none',
+                'update_comment_meta_cache' => false,
+            ];
+
+            if ( $postId > 0 ) {
+                $args['post_id'] = $postId;
+            }
+
+            $counts[ $key ] = (int) get_comments( $args );
+        }
+
+        return [ 'total' => $counts['approved'] + $counts['awaiting'] ] + $counts;
+    }
+}

--- a/tests/Unit/Services/CommentReviewTest.php
+++ b/tests/Unit/Services/CommentReviewTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * WooCommerce product reviews in the comment abilities.
+ *
+ * Reviews are comments with comment_type = 'review'. WooCommerce hides them
+ * from general comment queries, but its filter bails out whenever any of a
+ * dozen query vars is set — `type__not_in` among them, which other plugins
+ * (LearnDash sets `ld_review`) populate. The same list-comments call therefore
+ * returned different rows depending on which plugins a site happened to run.
+ * These tests pin the behaviour down so it no longer depends on the site.
+ *
+ * @package LightweightPlugins\SiteManager\Tests\Unit\Services
+ */
+
+declare(strict_types=1);
+
+namespace LightweightPlugins\SiteManager\Tests\Unit\Services;
+
+use LightweightPlugins\SiteManager\Services\CommentManager;
+use PHPUnit\Framework\TestCase;
+
+final class CommentReviewTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        reset_wp_caps();
+        reset_wp_comments();
+        grant_wp_caps( [ 'moderate_comments', 'edit_posts' ] );
+    }
+
+    protected function tearDown(): void {
+        reset_wp_caps();
+        reset_wp_comments();
+        parent::tearDown();
+    }
+
+    // =========================================================================
+    // Deterministic listing
+    // =========================================================================
+
+    /**
+     * Without an explicit type the query must pin itself to real comments, so
+     * reviews cannot leak in on sites where WooCommerce's own filter bails.
+     * WordPress maps type => 'comment' to comment_type IN ('', 'comment'), so
+     * legacy comments with an empty type are still returned.
+     */
+    public function test_list_comments_defaults_to_comment_type(): void {
+        CommentManager::list_comments( [] );
+
+        $this->assertSame( 'comment', $GLOBALS['wp_get_comments_last_args']['type'] ?? null );
+    }
+
+    public function test_list_comments_honours_an_explicit_review_type(): void {
+        CommentManager::list_comments( [ 'type' => 'review' ] );
+
+        $this->assertSame( 'review', $GLOBALS['wp_get_comments_last_args']['type'] ?? null );
+    }
+
+    // =========================================================================
+    // Review payload
+    // =========================================================================
+
+    public function test_review_output_includes_rating_and_verified(): void {
+        $GLOBALS['wp_comments_stub'] = [
+            new \WP_Comment( [ 'comment_ID' => 23, 'comment_type' => 'review', 'comment_post_ID' => 63 ] ),
+        ];
+        $GLOBALS['wp_comment_meta'][23] = [ 'rating' => 5, 'verified' => 1 ];
+
+        $result = CommentManager::list_comments( [ 'type' => 'review' ] );
+        $review = $result['comments'][0];
+
+        $this->assertSame( 'review', $review['type'] );
+        $this->assertSame( 5, $review['rating'] );
+        $this->assertTrue( $review['verified'] );
+    }
+
+    public function test_review_without_stored_rating_reports_null(): void {
+        $GLOBALS['wp_comments_stub'] = [
+            new \WP_Comment( [ 'comment_ID' => 24, 'comment_type' => 'review' ] ),
+        ];
+
+        $result = CommentManager::list_comments( [ 'type' => 'review' ] );
+
+        $this->assertNull( $result['comments'][0]['rating'] );
+        $this->assertFalse( $result['comments'][0]['verified'] );
+    }
+
+    /**
+     * A plain comment must not grow review-only fields.
+     */
+    public function test_plain_comment_has_no_rating_fields(): void {
+        $GLOBALS['wp_comments_stub'] = [
+            new \WP_Comment( [ 'comment_ID' => 1, 'comment_type' => 'comment' ] ),
+        ];
+
+        $result = CommentManager::list_comments( [] );
+
+        $this->assertArrayNotHasKey( 'rating', $result['comments'][0] );
+        $this->assertArrayNotHasKey( 'verified', $result['comments'][0] );
+    }
+
+    // =========================================================================
+    // Counts
+    // =========================================================================
+
+    /**
+     * Counts must not mix reviews into the comment totals — previously the two
+     * were summed together, and whether reviews were included at all depended
+     * on the site's other plugins.
+     */
+    public function test_counts_separate_reviews_from_comments(): void {
+        $GLOBALS['wp_comment_counts_stub'] = [
+            'comment:approve' => 4,
+            'comment:hold'    => 1,
+            'comment:spam'    => 2,
+            'review:approve'  => 7,
+            'review:hold'     => 3,
+            'review:spam'     => 0,
+        ];
+
+        $counts = CommentManager::get_counts();
+
+        $this->assertSame( 4, $counts['approved'] );
+        $this->assertSame( 1, $counts['awaiting'] );
+        $this->assertSame( 5, $counts['total'], 'total is approved + awaiting, reviews excluded' );
+
+        $this->assertArrayHasKey( 'reviews', $counts );
+        $this->assertSame( 7, $counts['reviews']['approved'] );
+        $this->assertSame( 3, $counts['reviews']['awaiting'] );
+        $this->assertSame( 10, $counts['reviews']['total'] );
+    }
+
+    public function test_counts_query_each_type_explicitly(): void {
+        CommentManager::get_counts();
+
+        $types = array_column( $GLOBALS['wp_get_comments_calls'] ?? [], 'type' );
+
+        $this->assertContains( 'comment', $types );
+        $this->assertContains( 'review', $types );
+    }
+}

--- a/tests/stubs/wordpress-functions.php
+++ b/tests/stubs/wordpress-functions.php
@@ -2116,3 +2116,128 @@ if ( ! function_exists( 'maybe_unserialize' ) ) {
         return $data;
     }
 }
+
+// ============================================================================
+// Comment stubs
+// ============================================================================
+
+if ( ! class_exists( 'WP_Comment' ) ) {
+    /**
+     * WP_Comment stub.
+     */
+    class WP_Comment {
+        public string $comment_ID = '0';
+        public string $comment_post_ID = '0';
+        public string $comment_author = 'Test Author';
+        public string $comment_author_email = 'author@example.com';
+        public string $comment_author_url = '';
+        public string $comment_author_IP = '127.0.0.1';
+        public string $comment_content = 'Test comment';
+        public string $comment_date = '2026-01-01 00:00:00';
+        public string $comment_date_gmt = '2026-01-01 00:00:00';
+        public string $comment_approved = '1';
+        public string $comment_parent = '0';
+        public string $comment_type = 'comment';
+        public string $comment_agent = '';
+        public string $user_id = '0';
+
+        /**
+         * @param array<string, mixed> $props Property overrides.
+         */
+        public function __construct( array $props = [] ) {
+            foreach ( $props as $key => $value ) {
+                if ( property_exists( $this, $key ) ) {
+                    $this->{$key} = (string) $value;
+                }
+            }
+        }
+    }
+}
+
+if ( ! function_exists( 'get_comments' ) ) {
+    /**
+     * Test double for get_comments(): records every args array it was called
+     * with, and returns $GLOBALS['wp_comments_stub'] (or a count when asked).
+     *
+     * @param array<string, mixed> $args Query args.
+     * @return array<int, WP_Comment>|int
+     */
+    function get_comments( array $args = [] ) {
+        $GLOBALS['wp_get_comments_calls'][] = $args;
+        $GLOBALS['wp_get_comments_last_args'] = $args;
+
+        if ( ! empty( $args['count'] ) ) {
+            $key = ( $args['type'] ?? 'any' ) . ':' . ( $args['status'] ?? 'all' );
+            return (int) ( $GLOBALS['wp_comment_counts_stub'][ $key ] ?? 0 );
+        }
+
+        return $GLOBALS['wp_comments_stub'] ?? [];
+    }
+}
+
+if ( ! function_exists( 'get_comment_meta' ) ) {
+    /**
+     * Get comment meta.
+     *
+     * @param int    $comment_id Comment ID.
+     * @param string $key        Meta key.
+     * @param bool   $single     Return single value.
+     * @return mixed
+     */
+    function get_comment_meta( int $comment_id, string $key = '', bool $single = false ) {
+        global $wp_comment_meta;
+        $value = $wp_comment_meta[ $comment_id ][ $key ] ?? null;
+        if ( null === $value ) {
+            return $single ? '' : [];
+        }
+        return $single ? $value : [ $value ];
+    }
+}
+
+if ( ! function_exists( 'wp_get_comment_status' ) ) {
+    /**
+     * Comment status.
+     *
+     * @param mixed $comment Comment.
+     */
+    function wp_get_comment_status( $comment ): string {
+        return 'approved';
+    }
+}
+
+if ( ! function_exists( 'get_avatar_url' ) ) {
+    /**
+     * Avatar URL.
+     *
+     * @param mixed                $id_or_email Identifier.
+     * @param array<string, mixed> $args        Args.
+     */
+    function get_avatar_url( $id_or_email, array $args = [] ): string {
+        return 'http://example.com/avatar.png';
+    }
+}
+
+if ( ! function_exists( 'get_the_title' ) ) {
+    /**
+     * Post title.
+     *
+     * @param int $post_id Post ID.
+     */
+    function get_the_title( int $post_id = 0 ): string {
+        return 'Test Post';
+    }
+}
+
+/**
+ * Reset recorded comment-query state between tests.
+ */
+function reset_wp_comments(): void {
+    global $wp_comment_meta;
+    $wp_comment_meta = [];
+    unset(
+        $GLOBALS['wp_get_comments_calls'],
+        $GLOBALS['wp_get_comments_last_args'],
+        $GLOBALS['wp_comments_stub'],
+        $GLOBALS['wp_comment_counts_stub']
+    );
+}


### PR DESCRIPTION
Follow-up to the question "does Site Manager handle WooCommerce comments?". The answer was: **order notes yes, product reviews only by accident** — this makes reviews deliberate and the behaviour deterministic.

## What was wrong

Reviews are comments with `comment_type = 'review'`. There are no review-specific abilities, but the generic comment abilities operated on them anyway — `get-comment`, `approve-comment`, `spam-comment` and friends all worked on a review ID. Three problems came out of that:

1. **The listing was environment-dependent.** WooCommerce hides reviews from comment queries via a `comments_clauses` filter, but that filter bails out whenever any of a dozen query vars is set — `type__not_in` among them, which **LearnDash** populates with `ld_review`. `list-comments` passed no `type`, so the *same call* returned reviews on one site and not on another. Confirmed live on the test store, where the review appeared precisely because of LearnDash.
2. **A review carried no review data.** `rating` and `verified` live in comment meta and were never read, so an agent could moderate a review without seeing the star rating.
3. **Counts silently mixed the two.** `wp_count_comments()` is filtered by WooCommerce through `get_comments()`, so it inherited the same ambiguity — the live store reported `total: 2` for 1 comment + 1 review.

## What changed

- `list-comments` defaults to `type: 'comment'`. WordPress maps that to `comment_type IN ( '', 'comment' )`, so **legacy comments with an empty type are still returned** — no silent data loss. `type=review` and `type=all` remain available.
- `format_comment()` adds `rating` (1-5, `null` when unset) and `verified`, on review rows only.
- `comment-counts` queries each type explicitly (new `Services\Comments\CommentCounter`) and reports reviews under a `reviews` key.
- Schema drift fixed: the comment schema advertised `author_name` / `avatar_url` where the fields are `author` / `avatar` and omitted `agent`, `replies_count`, `rating`, `verified`; the counts schema listed `pending` / `total_moderated`, which the ability never returned, while omitting `awaiting` / `post_trashed`, which it did.

**Order notes are untouched** — WooCommerce excludes `comment_type = 'order_note'` from every comment query unconditionally, and `wc-list-order-notes` / `wc-add-order-note` already cover them properly.

## Verified live (WooCommerce 11.0, HPOS)

| Check | Result |
|---|---|
| default `list-comments` with a review present | returns only the comment — deterministic |
| `list-comments type=review` | `rating: 4`, `verified: true` |
| `get-comment` on a review | `rating` / `verified` present |
| `get-comment` on a plain comment | no `rating` key |
| `comment-counts` | `total: 1` + `reviews: { total: 1 }`, separated |
| `type=all` | both types |
| order notes (21 in DB) | still excluded from every listing |

## Tests

`tests/Unit/Services/CommentReviewTest.php` — 7 cases, **red before, green after**. This path had **no unit coverage at all**, so `get_comments`, `get_comment_meta`, `wp_get_comment_status` and a `WP_Comment` class were added to the stubs.

**Gate:** phpcs clean · PHPStan L5 no errors · **432/432** tests.

## ⚠️ Behaviour change

`list-comments` no longer returns reviews by default, and `comment-counts` numbers change shape (reviews split out, and its totals no longer include reviews on sites where they previously did). Released as **1.4.1**.
